### PR TITLE
updated preprocess_spk.py

### DIFF
--- a/preprocess_spk.py
+++ b/preprocess_spk.py
@@ -12,31 +12,30 @@ import glob
 import argparse
 
 
-def build_from_path(in_dir, out_dir, weights_fpath, num_workers=1):
+def build_from_path(in_dir, out_dir, encoder, num_workers=1):
     executor = ProcessPoolExecutor(max_workers=num_workers)
     futures = []
     wavfile_paths = glob.glob(os.path.join(in_dir, '*.wav'))
     wavfile_paths= sorted(wavfile_paths)
     for wav_path in wavfile_paths:
         futures.append(executor.submit(
-            partial(_compute_spkEmbed, out_dir, wav_path, weights_fpath)))
+            partial(_compute_spkEmbed, out_dir, wav_path, encoder)))
     return [future.result() for future in tqdm(futures)]
 
-def _compute_spkEmbed(out_dir, wav_path, weights_fpath):
+def _compute_spkEmbed(out_dir, wav_path, encoder):
     utt_id = os.path.basename(wav_path).rstrip(".wav")
     fpath = Path(wav_path)
     wav = preprocess_wav(fpath)
 
-    encoder = SpeakerEncoder(weights_fpath)
     embed = encoder.embed_utterance(wav)
     fname_save = os.path.join(out_dir, f"{utt_id}.npy")
     np.save(fname_save, embed, allow_pickle=False)
     return os.path.basename(fname_save)
 
-def preprocess(in_dir, out_dir_root, spk, weights_fpath, num_workers):
+def preprocess(in_dir, out_dir_root, spk, encoder, num_workers):
     out_dir = os.path.join(out_dir_root, spk)
     os.makedirs(out_dir, exist_ok=True)
-    metadata = build_from_path(in_dir, out_dir, weights_fpath, num_workers)
+    metadata = build_from_path(in_dir, out_dir, encoder, num_workers)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -62,6 +61,11 @@ if __name__ == "__main__":
     print("[INFO] spk_embed_out_dir: ", spk_embed_out_dir)
     os.makedirs(spk_embed_out_dir, exist_ok=True)
 
+    if os.path.isfile(args.spk_encoder_ckpt):
+        encoder = SpeakerEncoder(args.spk_encoder_ckpt)
+    else:
+        raise FileNotFoundError(f"{args.spk_encoder_ckpt} was not found or is a directory")
+        
     #for data_split in split_list:
     #    sub_folder_list = os.listdir(args.in_dir, data_split) 
     for spk in sub_folder_list:
@@ -70,7 +74,7 @@ if __name__ == "__main__":
         if not os.path.isdir(in_dir): 
             continue
         #out_dir = os.path.join(args.out_dir, spk)
-        preprocess(in_dir, spk_embed_out_dir, spk, args.spk_encoder_ckpt, args.num_workers)
+        preprocess(in_dir, spk_embed_out_dir, spk, encoder, args.num_workers)
     '''
     for data_split in split_list:
         in_dir = os.path.join(args.in_dir, data_split)
@@ -79,5 +83,3 @@ if __name__ == "__main__":
 
     print("DONE!")
     sys.exit(0)
-
-

--- a/preprocess_spk.py
+++ b/preprocess_spk.py
@@ -11,18 +11,20 @@ from functools import partial
 import glob 
 import argparse
 
+weights_fpath = "speaker_encoder/ckpt/pretrained_bak_5805000.pt"
+encoder = SpeakerEncoder(weights_fpath)
 
-def build_from_path(in_dir, out_dir, encoder, num_workers=1):
+def build_from_path(in_dir, out_dir, weights_fpath, num_workers=1):
     executor = ProcessPoolExecutor(max_workers=num_workers)
     futures = []
     wavfile_paths = glob.glob(os.path.join(in_dir, '*.wav'))
     wavfile_paths= sorted(wavfile_paths)
     for wav_path in wavfile_paths:
         futures.append(executor.submit(
-            partial(_compute_spkEmbed, out_dir, wav_path, encoder)))
+            partial(_compute_spkEmbed, out_dir, wav_path, weights_fpath)))
     return [future.result() for future in tqdm(futures)]
 
-def _compute_spkEmbed(out_dir, wav_path, encoder):
+def _compute_spkEmbed(out_dir, wav_path, weights_fpath):
     utt_id = os.path.basename(wav_path).rstrip(".wav")
     fpath = Path(wav_path)
     wav = preprocess_wav(fpath)
@@ -32,10 +34,10 @@ def _compute_spkEmbed(out_dir, wav_path, encoder):
     np.save(fname_save, embed, allow_pickle=False)
     return os.path.basename(fname_save)
 
-def preprocess(in_dir, out_dir_root, spk, encoder, num_workers):
+def preprocess(in_dir, out_dir_root, spk, weights_fpath, num_workers):
     out_dir = os.path.join(out_dir_root, spk)
     os.makedirs(out_dir, exist_ok=True)
-    metadata = build_from_path(in_dir, out_dir, encoder, num_workers)
+    metadata = build_from_path(in_dir, out_dir, weights_fpath, num_workers)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -61,11 +63,6 @@ if __name__ == "__main__":
     print("[INFO] spk_embed_out_dir: ", spk_embed_out_dir)
     os.makedirs(spk_embed_out_dir, exist_ok=True)
 
-    if os.path.isfile(args.spk_encoder_ckpt):
-        encoder = SpeakerEncoder(args.spk_encoder_ckpt)
-    else:
-        raise FileNotFoundError(f"{args.spk_encoder_ckpt} was not found or is a directory")
-        
     #for data_split in split_list:
     #    sub_folder_list = os.listdir(args.in_dir, data_split) 
     for spk in sub_folder_list:
@@ -74,7 +71,7 @@ if __name__ == "__main__":
         if not os.path.isdir(in_dir): 
             continue
         #out_dir = os.path.join(args.out_dir, spk)
-        preprocess(in_dir, spk_embed_out_dir, spk, encoder, args.num_workers)
+        preprocess(in_dir, spk_embed_out_dir, spk, args.spk_encoder_ckpt, args.num_workers)
     '''
     for data_split in split_list:
         in_dir = os.path.join(args.in_dir, data_split)
@@ -83,3 +80,5 @@ if __name__ == "__main__":
 
     print("DONE!")
     sys.exit(0)
+
+

--- a/preprocess_spk.py
+++ b/preprocess_spk.py
@@ -25,6 +25,7 @@ def build_from_path(in_dir, out_dir, weights_fpath, num_workers=1):
     return [future.result() for future in tqdm(futures)]
 
 def _compute_spkEmbed(out_dir, wav_path, weights_fpath):
+    global encoder
     utt_id = os.path.basename(wav_path).rstrip(".wav")
     fpath = Path(wav_path)
     wav = preprocess_wav(fpath)


### PR DESCRIPTION
Hi @OlaWod , 

Based on num_workers, the [Speaker Encoder loads N times](https://github.com/OlaWod/FreeVC/blob/main/preprocess_spk.py#L30) and computes speaker embedding every time. to avoid that globally loading the speaker encoder and pass into _compute_spkEmbed is a good solution. so I checked from my end, it is working fine.

Please feel free to look it over, and if it is useful merge it. 

Thanks