### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ numpy==1.21.6
 scipy==1.7.2
 tensorboard==2.7.0
 torch==1.10.0
-torchvision==0.9.0
+torchvision==0.11.1
 webrtcvad==2.0.10


### PR DESCRIPTION
The dependencies for torch and torchvision were incompatible. Torch 1.10.0 utilizes torchvision 0.11.1 instead of 0.9.0.